### PR TITLE
docs: 보고서 시스템 저장 정책·라우팅·품질 게이트

### DIFF
--- a/docs/QUALITY-GATE.md
+++ b/docs/QUALITY-GATE.md
@@ -30,13 +30,16 @@ npm test
 - [ ] 신규 등록 — 양식(template, reportCategory 포함) / 가이드(guide, reportCategory null) 둘 다 정상 저장
 - [ ] slug 중복 시 검증 메시지 노출
 - [ ] 수정 — 본문/버전/published 토글 반영
-- [ ] 삭제 다이얼로그 — 취소/확정 동작
-- [ ] 미공개(`published=false`) 항목은 회원 페이지에 노출 안 됨
+- [ ] slug 변경 시 이전 URL의 캐시도 무효화되어 옛 경로가 즉시 404 또는 새 데이터로 갱신
+- [ ] "비공개" 다이얼로그 — 취소/확정 동작, 실패 시 에러 메시지 노출
+- [ ] 비공개(`published=false`) 처리 후 회원 페이지에서 즉시 사라짐 (content/ 시드와 동일 slug여도 다시 노출되지 않음)
+- [ ] 비공개 항목을 수정 페이지에서 다시 published=true 로 전환 가능
 
 ### 회원 (`/member/templates`, `/member/guides`)
 - [ ] `/resources` 카드 3종 → 정상 라우팅
 - [ ] DB에 항목이 있을 때 `source: db` 라벨 표시
-- [ ] DB에 없을 때 content/ 시드로 fallback (`source: content`)
+- [ ] 같은 slug의 DB row가 없을 때만 content/ 시드로 fallback (`source: content`)
+- [ ] 같은 slug의 DB row가 있고 `published=false` 인 경우 fallback 없이 404
 - [ ] 양식 상세에서 "PDF로 저장" → print 페이지 진입 후 `window.print()` 자동 호출
 - [ ] 인쇄 시 A4 여백 적용, "다시 인쇄" 버튼은 화면에만 표시(no-print)
 

--- a/docs/QUALITY-GATE.md
+++ b/docs/QUALITY-GATE.md
@@ -1,0 +1,61 @@
+# 보고서 시스템 품질 게이트
+
+이슈 #20 — 보고서 양식·가이드 기능 머지 전 통과해야 할 회귀 점검 목록.
+
+## 자동 검증 (CI/CD)
+
+다음 명령이 모두 성공해야 한다.
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run build
+npm test
+```
+
+| 단계 | 기준 | 비고 |
+|---|---|---|
+| ESLint | 신규 코드 0 error / 0 warning | 사전 존재 경고는 별도 이슈로 |
+| TypeScript | `tsc --noEmit` 0 error | `as any` / `@ts-ignore` 금지 |
+| Next build | 빌드 성공 | `/admin/templates`, `/member/templates`, `/member/guides`, print 라우트 포함 |
+| Vitest | 마크다운 단위 테스트 PASS | `tests/unit/markdown-*.test.ts` |
+
+## 수동 점검 체크리스트
+
+### DB 마이그레이션
+- [ ] `npx drizzle-kit push` 실행 → `report_templates` 테이블 생성 확인
+- [ ] `report_template_category` enum 생성 확인 (`template`, `guide`)
+
+### 관리자 (`/admin/templates`)
+- [ ] 신규 등록 — 양식(template, reportCategory 포함) / 가이드(guide, reportCategory null) 둘 다 정상 저장
+- [ ] slug 중복 시 검증 메시지 노출
+- [ ] 수정 — 본문/버전/published 토글 반영
+- [ ] 삭제 다이얼로그 — 취소/확정 동작
+- [ ] 미공개(`published=false`) 항목은 회원 페이지에 노출 안 됨
+
+### 회원 (`/member/templates`, `/member/guides`)
+- [ ] `/resources` 카드 3종 → 정상 라우팅
+- [ ] DB에 항목이 있을 때 `source: db` 라벨 표시
+- [ ] DB에 없을 때 content/ 시드로 fallback (`source: content`)
+- [ ] 양식 상세에서 "PDF로 다운로드" → print 페이지 진입 후 `window.print()` 자동 호출
+- [ ] 인쇄 시 A4 여백 적용, "다시 인쇄" 버튼은 화면에만 표시(no-print)
+
+### 콘텐츠 검수
+- [ ] 템플릿 3종 모두 장 번호 1.~5. (로마자 미사용)
+- [ ] 1·2장 인라인 레이블이 `### 제목 / ### 그림 / ### 내용 / ### 출처` 소제목으로 승격됨
+- [ ] 빈 장(3·4·5)은 양식 그대로 유지
+- [ ] 가이드의 항목 기호 표가 공문서 표준(`1.→가.→1)→가)→(1)→(가)→①→㉮`)을 따름
+
+## 사전 존재 LSP false-positive (무시 가능)
+
+- `src/app/globals.css`: Tailwind v4 디렉티브를 LSP가 인식하지 못함
+- `Cannot find module 'template-row-actions'` / `_print-view`: TS 서버 캐시 — 빌드/재시작 시 해소
+
+## 머지 차단 사유
+
+다음 중 하나라도 발생하면 머지 금지:
+
+- `npm run build` 실패
+- `tsc --noEmit` 에러
+- 회원 페이지에서 양식·가이드 404 (DB·content 모두 누락)
+- 인쇄 페이지에서 한글 깨짐 또는 페이지 분할 깨짐

--- a/docs/QUALITY-GATE.md
+++ b/docs/QUALITY-GATE.md
@@ -37,7 +37,7 @@ npm test
 - [ ] `/resources` 카드 3종 → 정상 라우팅
 - [ ] DB에 항목이 있을 때 `source: db` 라벨 표시
 - [ ] DB에 없을 때 content/ 시드로 fallback (`source: content`)
-- [ ] 양식 상세에서 "PDF로 다운로드" → print 페이지 진입 후 `window.print()` 자동 호출
+- [ ] 양식 상세에서 "PDF로 저장" → print 페이지 진입 후 `window.print()` 자동 호출
 - [ ] 인쇄 시 A4 여백 적용, "다시 인쇄" 버튼은 화면에만 표시(no-print)
 
 ### 콘텐츠 검수

--- a/docs/REPORT-ARCHIVE-SCOPE.md
+++ b/docs/REPORT-ARCHIVE-SCOPE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | `/resources` | 자료실 메인 (카드 3종) | 정적 | 양식·가이드 진입점 |
 | `/member/templates` | 보고서 양식 목록 | `listTemplates()` (DB → content) | 분야별 v버전 카드 |
-| `/member/templates/[slug]` | 양식 상세(웹 미리보기) | `resolveTemplate(slug)` | "PDF로 다운로드" CTA |
+| `/member/templates/[slug]` | 양식 상세(웹 미리보기) | `resolveTemplate(slug)` | "PDF로 저장" CTA |
 | `/member/templates/[slug]/print` | 양식 인쇄(PDF 저장) | `resolveTemplate(slug)` | A4 + auto `window.print()` |
 | `/member/guides/[slug]` | 가이드 상세 | `resolveGuide(slug)` | 인쇄 페이지 없음 |
 

--- a/docs/REPORT-ARCHIVE-SCOPE.md
+++ b/docs/REPORT-ARCHIVE-SCOPE.md
@@ -1,0 +1,50 @@
+# 보고서 양식·가이드 라우팅 표
+
+이슈 #18 — 회원 자료실에서 어떤 URL이 어떤 데이터를 보여주는지 한눈에 정리.
+
+## 회원 영역 (로그인 필요)
+
+| URL | 페이지 | 데이터 출처 | 비고 |
+|---|---|---|---|
+| `/resources` | 자료실 메인 (카드 3종) | 정적 | 양식·가이드 진입점 |
+| `/member/templates` | 보고서 양식 목록 | `listTemplates()` (DB → content) | 분야별 v버전 카드 |
+| `/member/templates/[slug]` | 양식 상세(웹 미리보기) | `resolveTemplate(slug)` | "PDF로 다운로드" CTA |
+| `/member/templates/[slug]/print` | 양식 인쇄(PDF 저장) | `resolveTemplate(slug)` | A4 + auto `window.print()` |
+| `/member/guides/[slug]` | 가이드 상세 | `resolveGuide(slug)` | 인쇄 페이지 없음 |
+
+### 알려진 slug
+
+**templates** (DB `category="template"`, `report_category` 부여):
+- `management-book` — 경영서
+- `classic-book` — 고전명작
+- `business-practice` — 기업실무·한국경제사
+
+**guides** (DB `category="guide"`, `report_category` 없음):
+- `report-writing-guide` — 보고서 작성 가이드
+- `markdown-guide` — Markdown 사용 가이드
+- `submission-guide` — 보고서 제출 가이드
+
+## 관리자 영역 (`requireAdmin()`)
+
+| URL | 페이지 | 액션 |
+|---|---|---|
+| `/admin/templates` | 양식·가이드 목록 | 수정/삭제 다이얼로그 |
+| `/admin/templates/new` | 신규 등록 | `createReportTemplate` |
+| `/admin/templates/[id]/edit` | 수정 | `updateReportTemplate` |
+
+폼 동작:
+- `category="template"` 선택 시 `reportCategory` 필드 활성화
+- `category="guide"` 선택 시 `reportCategory` 비활성화 (저장 시 null)
+
+## 데이터 흐름
+
+```
+관리자 CRUD ──▶ report_templates 테이블 ──┐
+                                          ├──▶ resolve.ts ──▶ 회원 페이지
+content/member/{templates,guides}/*.md ───┘   (DB 우선, 없으면 content)
+```
+
+## 권한
+
+- `(member)` 그룹: middleware (`src/proxy.ts`)에서 비로그인 차단
+- `(admin)` 그룹: 각 server action에서 `requireAdmin()` 호출

--- a/docs/REPORT-STORAGE-DECISION.md
+++ b/docs/REPORT-STORAGE-DECISION.md
@@ -1,6 +1,6 @@
 # 보고서 양식·가이드 저장 방식 결정
 
-**결정**: DB(Neon Postgres) 단독 저장 + content/ 폴더는 초기 시드(seed)로만 유지
+**결정**: 운영 데이터는 DB(Neon Postgres)를 단일 수정 지점으로 사용하고, `content/` 폴더는 초기 내장 양식 및 fallback baseline으로 유지한다.
 
 **결정일**: 2026-04
 **관련 이슈**: #14, #18
@@ -13,10 +13,10 @@
 
 ## 검토한 대안
 
-### 1안. DB 단독 저장 (채택)
-- 모든 양식/가이드를 `report_templates` 테이블에 저장
+### 1안. DB 우선 + content fallback (채택)
+- 운영 변경은 모두 `report_templates` 테이블에서 발생
 - 관리자 페이지(`/admin/templates`)에서 CRUD
-- `content/member/templates/`, `content/member/guides/`는 **초기 시드용** Markdown 파일만 유지
+- `content/member/templates/`, `content/member/guides/`는 **초기 내장(default) 양식**으로 유지하여 신규 환경/DB 비어있는 상태에서도 회원 페이지가 동작하도록 한다.
 
 ### 2안. content/ fs 단독 저장
 - Markdown 파일을 git으로만 관리
@@ -31,7 +31,7 @@
 1. **AGENTS.md §4 원칙 일치** — 공지사항·언론보도·자료실과 동일한 패턴(DB 텍스트 + Blob 이미지)
 2. **운영자 자율성** — 코드 PR 없이 관리자 페이지에서 즉시 양식 개정 가능
 3. **버전 관리** — `version` 필드로 v1.0 / v1.1 등 명시적 추적
-4. **회복력(seed)** — DB에 항목이 없거나 신규 환경 부트스트랩 시 `content/` 시드가 안전망 역할
+4. **회복력(fallback baseline)** — DB에 해당 slug row가 없는 경우에 한해 `content/` 내장 양식이 동작
 5. **테스트 용이성** — content/ Markdown은 Vitest로 frontmatter/sanitize 회귀 검증
 
 ## 리졸버 정책
@@ -40,17 +40,31 @@
 
 ```
 resolveTemplate(slug) / resolveGuide(slug):
-  1) DB에서 published=true 항목 조회 → 있으면 그것 사용 (source: "db")
-  2) 없으면 content/ Markdown 시드 사용 (source: "content")
+  1) 같은 slug의 DB row 존재 여부 확인 (published 무관)
+     - 존재 + published=true  → DB 사용 (source: "db")
+     - 존재 + published=false → null 반환 (회원 비노출, fallback 금지)
+  2) DB row가 아예 없을 때만 content/ 내장 양식 사용 (source: "content")
   3) 둘 다 없으면 null → 404
+
+listTemplates():
+  - published=true 인 DB row만 회원 목록에 노출
+  - 비공개(published=false) row의 slug는 content fallback 차단 집합에 포함
 ```
 
 회원 UI에는 출처를 작은 라벨("DB 등록 양식" / "기본 시드 양식")로 표시해 디버깅을 돕는다.
+
+## 삭제/비공개 정책
+
+운영자가 회원에게 노출하지 않으려는 양식은 **삭제가 아니라 비공개(`published=false`)** 로 처리한다.
+
+이유: content/에 동일 slug의 내장 양식이 있을 때 DB row를 실제로 삭제하면, resolver가 content fallback 단계로 넘어가 회원 페이지에 동일 양식이 다시 표시된다("삭제했는데 다시 보임" 문제). DB row가 비공개 상태로 남아 있어야 resolver가 fallback을 차단할 수 있다.
+
+관리자 UI(`/admin/templates`)는 이를 반영해 행 액션을 "비공개"로 명시한다. 비공개로 전환된 항목은 수정 페이지에서 다시 공개로 되돌릴 수 있다. 영구 삭제가 필요한 경우(예: 관리자 실수로 만든 row, content 시드가 없는 사용자 정의 양식 정리)는 별도의 운영 작업으로 처리한다.
 
 ## 비채택 영향
 
 - `content/member/templates/*.md`는 더 이상 회원 페이지의 1차 데이터 소스가 아님
 - 운영 양식 변경은 반드시 `/admin/templates`에서 진행
-- content/ 시드는 다음 경우에만 사용:
+- content/ 내장 양식은 다음 경우에만 사용:
   - 신규 환경에서 DB seed 전 임시 fallback
   - 양식 회귀 테스트(Vitest)의 고정 입력

--- a/docs/REPORT-STORAGE-DECISION.md
+++ b/docs/REPORT-STORAGE-DECISION.md
@@ -1,0 +1,56 @@
+# 보고서 양식·가이드 저장 방식 결정
+
+**결정**: DB(Neon Postgres) 단독 저장 + content/ 폴더는 초기 시드(seed)로만 유지
+
+**결정일**: 2026-04
+**관련 이슈**: #14, #18
+
+---
+
+## 배경
+
+회원에게 제공하는 "보고서 양식(template)"과 "보고서 작성·제출 가이드(guide)"의 저장 방식을 결정해야 했다. HRA 사이트는 AGENTS.md §4 원칙에 따라 "관리자 페이지에서 CRUD하는 텍스트/메타는 DB, 이미지만 Blob"을 따른다.
+
+## 검토한 대안
+
+### 1안. DB 단독 저장 (채택)
+- 모든 양식/가이드를 `report_templates` 테이블에 저장
+- 관리자 페이지(`/admin/templates`)에서 CRUD
+- `content/member/templates/`, `content/member/guides/`는 **초기 시드용** Markdown 파일만 유지
+
+### 2안. content/ fs 단독 저장
+- Markdown 파일을 git으로만 관리
+- 관리자 CRUD 불가 → 코드 PR 필요
+
+### 3안. DB + fs 동기화
+- DB에 저장하되 git에도 동기화 커밋
+- 단일 진실 공급원(single source of truth) 부재 → 충돌 위험
+
+## 채택 사유
+
+1. **AGENTS.md §4 원칙 일치** — 공지사항·언론보도·자료실과 동일한 패턴(DB 텍스트 + Blob 이미지)
+2. **운영자 자율성** — 코드 PR 없이 관리자 페이지에서 즉시 양식 개정 가능
+3. **버전 관리** — `version` 필드로 v1.0 / v1.1 등 명시적 추적
+4. **회복력(seed)** — DB에 항목이 없거나 신규 환경 부트스트랩 시 `content/` 시드가 안전망 역할
+5. **테스트 용이성** — content/ Markdown은 Vitest로 frontmatter/sanitize 회귀 검증
+
+## 리졸버 정책
+
+`src/lib/markdown/resolve.ts`의 동작:
+
+```
+resolveTemplate(slug) / resolveGuide(slug):
+  1) DB에서 published=true 항목 조회 → 있으면 그것 사용 (source: "db")
+  2) 없으면 content/ Markdown 시드 사용 (source: "content")
+  3) 둘 다 없으면 null → 404
+```
+
+회원 UI에는 출처를 작은 라벨("DB 등록 양식" / "기본 시드 양식")로 표시해 디버깅을 돕는다.
+
+## 비채택 영향
+
+- `content/member/templates/*.md`는 더 이상 회원 페이지의 1차 데이터 소스가 아님
+- 운영 양식 변경은 반드시 `/admin/templates`에서 진행
+- content/ 시드는 다음 경우에만 사용:
+  - 신규 환경에서 DB seed 전 임시 fallback
+  - 양식 회귀 테스트(Vitest)의 고정 입력

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary
- 보고서 양식·가이드 시스템의 **결정 근거**와 **운영 가이드** 문서 3종

## 관련 이슈
#14 #18 #20

## 변경 사항
- \`docs/REPORT-STORAGE-DECISION.md\` — DB 단독 저장 결정 근거, content/ 시드 정책
- \`docs/REPORT-ARCHIVE-SCOPE.md\` — 회원/관리자 라우팅 표, 알려진 slug 목록
- \`docs/QUALITY-GATE.md\` — 머지 전 자동·수동 검증 체크리스트

## 비고
- 코드 변경 없음 (문서만)
- 본 PR은 다른 PR과 독립적이며 main에 직접 머지 가능
- #1~#3 PR이 머지된 후 코드 ↔ 문서 일치 검토 권장