### PR TITLE
feat(member): 보고서 양식·가이드 회원 페이지 + PDF 인쇄

### DIFF
--- a/src/app/(member)/member/guides/[slug]/page.tsx
+++ b/src/app/(member)/member/guides/[slug]/page.tsx
@@ -1,0 +1,76 @@
+/**
+ * 회원 — 가이드 상세 페이지
+ *
+ * 역할: 보고서 작성 가이드 / 마크다운 가이드 / 제출 가이드 등의 본문(Markdown)을 표시.
+ *       데이터 출처는 DB → content/ 순으로 자동 조회한다.
+ *
+ * URL: /member/guides/[slug]
+ *   - report-writing-guide
+ *   - markdown-guide
+ *   - submission-guide
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { MarkdownViewer } from "@/components/markdown/markdown-viewer";
+import { resolveGuide } from "@/lib/markdown/resolve";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const guide = await resolveGuide(slug);
+  return {
+    title: guide ? guide.title : "가이드",
+  };
+}
+
+export default async function MemberGuideDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const guide = await resolveGuide(slug);
+
+  if (!guide) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 sm:px-6 py-12 sm:py-20">
+      <div className="mb-6">
+        <Button variant="outline" render={<Link href="/resources" />}>
+          <ArrowLeft className="size-4" />
+          자료실로
+        </Button>
+      </div>
+
+      <header className="mb-8 space-y-3 border-b border-[#D9D9D9] pb-6">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge
+            variant="outline"
+            className="border-[#D9D9D9] bg-white text-[#666666]"
+          >
+            v{guide.version}
+          </Badge>
+          <span className="text-xs text-[#666666]">
+            {guide.source === "db" ? "DB 등록 가이드" : "기본 시드 가이드"}
+          </span>
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight text-[#1a1a1a]">
+          {guide.title}
+        </h1>
+        {guide.description ? (
+          <p className="text-sm text-[#666666]">{guide.description}</p>
+        ) : null}
+      </header>
+
+      <MarkdownViewer body={guide.body} />
+    </div>
+  );
+}

--- a/src/app/(member)/member/templates/[slug]/page.tsx
+++ b/src/app/(member)/member/templates/[slug]/page.tsx
@@ -48,7 +48,7 @@ export default async function MemberTemplateDetailPage({ params }: Props) {
           className="bg-[#1a1a1a] text-white hover:bg-[#333333]"
         >
           <Printer className="size-4" />
-          PDF로 다운로드
+          PDF로 저장
         </Button>
       </div>
 

--- a/src/app/(member)/member/templates/[slug]/page.tsx
+++ b/src/app/(member)/member/templates/[slug]/page.tsx
@@ -1,0 +1,87 @@
+/**
+ * 회원 — 보고서 양식 상세 페이지
+ *
+ * 역할: 양식 본문(Markdown)을 미리 보고, PDF 인쇄 페이지로 이동할 수 있는 진입점.
+ *       데이터는 DB → content/ 순으로 자동 조회한다.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, Printer } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { MarkdownViewer } from "@/components/markdown/markdown-viewer";
+import { resolveTemplate } from "@/lib/markdown/resolve";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const template = await resolveTemplate(slug);
+  return {
+    title: template ? template.title : "보고서 양식",
+  };
+}
+
+export default async function MemberTemplateDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const template = await resolveTemplate(slug);
+
+  if (!template) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 sm:px-6 py-12 sm:py-20">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <Button variant="outline" render={<Link href="/member/templates" />}>
+          <ArrowLeft className="size-4" />
+          목록으로
+        </Button>
+        <Button
+          render={<Link href={`/member/templates/${template.slug}/print`} />}
+          className="bg-[#1a1a1a] text-white hover:bg-[#333333]"
+        >
+          <Printer className="size-4" />
+          PDF로 다운로드
+        </Button>
+      </div>
+
+      <header className="mb-8 space-y-3 border-b border-[#D9D9D9] pb-6">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge
+            variant="outline"
+            className="border-[#D9D9D9] bg-white text-[#666666]"
+          >
+            v{template.version}
+          </Badge>
+          {template.reportCategory ? (
+            <Badge className="bg-blue-100 text-blue-800">
+              {template.reportCategory === "management-book"
+                ? "경영서"
+                : template.reportCategory === "classic-book"
+                  ? "고전명작"
+                  : "기업실무·한국경제사"}
+            </Badge>
+          ) : null}
+          <span className="text-xs text-[#666666]">
+            {template.source === "db" ? "DB 등록 양식" : "기본 시드 양식"}
+          </span>
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight text-[#1a1a1a]">
+          {template.title}
+        </h1>
+        {template.description ? (
+          <p className="text-sm text-[#666666]">{template.description}</p>
+        ) : null}
+      </header>
+
+      <MarkdownViewer body={template.body} />
+    </div>
+  );
+}

--- a/src/app/(member)/member/templates/[slug]/print/_print-view.tsx
+++ b/src/app/(member)/member/templates/[slug]/print/_print-view.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * 양식 인쇄 뷰 (클라이언트 컴포넌트)
+ *
+ * 역할: A4 인쇄용 레이아웃을 그리고, 마운트 시 한 번 window.print()를 호출한다.
+ *       useRef 가드로 React Strict Mode의 더블 마운트에서도 한 번만 실행되도록 한다.
+ */
+
+import { useEffect, useRef } from "react";
+import { MarkdownViewer } from "@/components/markdown/markdown-viewer";
+
+type Props = {
+  title: string;
+  fileTitle: string;
+  version: string;
+  description: string | null;
+  body: string;
+};
+
+export function PrintView({ title, fileTitle, version, description, body }: Props) {
+  const printedRef = useRef(false);
+
+  useEffect(() => {
+    document.title = fileTitle;
+    if (printedRef.current) return;
+    printedRef.current = true;
+    // 폰트/이미지 로딩이 어느 정도 마무리된 뒤 인쇄 다이얼로그 호출
+    const timer = window.setTimeout(() => {
+      window.print();
+    }, 400);
+    return () => window.clearTimeout(timer);
+  }, [fileTitle]);
+
+  return (
+    <>
+      {/* A4 인쇄 전용 스타일 — 화면 폭 제한과 페이지 여백을 함께 정의한다 */}
+      <style>{`
+        @page {
+          size: A4;
+          margin: 20mm 18mm;
+        }
+        @media print {
+          .no-print { display: none !important; }
+          body { background: #ffffff !important; }
+          .print-page { padding: 0 !important; max-width: none !important; }
+          h1, h2, h3 { page-break-after: avoid; }
+          pre, table, blockquote { page-break-inside: avoid; }
+        }
+      `}</style>
+
+      <div className="print-page mx-auto max-w-4xl px-6 py-12 print:px-0 print:py-0">
+        <div className="no-print mb-6 flex flex-wrap items-center justify-between gap-3 rounded-md border border-[#D9D9D9] bg-white p-4">
+          <p className="text-sm text-[#666666]">
+            인쇄 다이얼로그가 자동으로 열립니다. 대상에서 <strong className="text-[#1a1a1a]">PDF로 저장</strong>을 선택하세요.
+          </p>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="rounded-md bg-[#1a1a1a] px-4 py-2 text-sm font-medium text-white hover:bg-[#333333]"
+          >
+            다시 인쇄
+          </button>
+        </div>
+
+        <header className="mb-8 border-b border-[#D9D9D9] pb-4">
+          <p className="text-xs text-[#666666]">HRA 보고서 양식 · v{version}</p>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight text-[#1a1a1a]">
+            {title}
+          </h1>
+          {description ? (
+            <p className="mt-2 text-sm text-[#666666]">{description}</p>
+          ) : null}
+        </header>
+
+        <MarkdownViewer body={body} />
+      </div>
+    </>
+  );
+}

--- a/src/app/(member)/member/templates/[slug]/print/page.tsx
+++ b/src/app/(member)/member/templates/[slug]/print/page.tsx
@@ -1,0 +1,42 @@
+/**
+ * 회원 — 보고서 양식 인쇄(PDF 다운로드) 페이지
+ *
+ * 역할: 양식 본문을 A4 인쇄에 최적화된 레이아웃으로 표시하고,
+ *       페이지 진입 시 자동으로 브라우저 인쇄 다이얼로그를 띄운다.
+ *       사용자는 "PDF로 저장"을 선택해 파일로 내려받을 수 있다.
+ *
+ * 파일명 규칙(브라우저 인쇄 다이얼로그 기본 제목): document.title을
+ *   "HRA보고서양식_{양식명}_v{버전}" 형태로 지정한다.
+ *   사용자가 실제 PDF 파일로 저장 시 이 제목이 파일명 후보가 된다.
+ */
+
+import { notFound } from "next/navigation";
+import { resolveTemplate } from "@/lib/markdown/resolve";
+import { PrintView } from "./_print-view";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export default async function MemberTemplatePrintPage({ params }: Props) {
+  const { slug } = await params;
+  const template = await resolveTemplate(slug);
+
+  if (!template) {
+    notFound();
+  }
+
+  const fileTitle = `HRA보고서양식_${template.title}_v${template.version}`;
+
+  return (
+    <PrintView
+      title={template.title}
+      fileTitle={fileTitle}
+      version={template.version}
+      description={template.description}
+      body={template.body}
+    />
+  );
+}

--- a/src/app/(member)/member/templates/page.tsx
+++ b/src/app/(member)/member/templates/page.tsx
@@ -56,7 +56,7 @@ export default async function MemberTemplatesPage() {
           보고서 양식
         </h1>
         <p className="max-w-2xl text-sm text-[#666666] md:text-base mx-auto sm:mx-0">
-          분야별 보고서 작성용 표준 양식입니다. 양식을 미리 보고 PDF로 다운로드하여 사용하세요.
+          분야별 보고서 작성용 표준 양식입니다. 양식을 미리 보고 PDF로 저장하여 사용하세요.
         </p>
         <div className="flex flex-wrap items-center gap-2 text-sm">
           <Link

--- a/src/app/(member)/member/templates/page.tsx
+++ b/src/app/(member)/member/templates/page.tsx
@@ -1,0 +1,142 @@
+/**
+ * 회원 — 보고서 양식 목록 페이지
+ *
+ * 역할: 회원이 사용할 수 있는 보고서 양식 목록을 표시한다.
+ *       각 카드에서 양식 상세로 이동하면 본문(Markdown)을 미리 보고 PDF로 받을 수 있다.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, FileCheck2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { listTemplates } from "@/lib/markdown/resolve";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "보고서 양식",
+};
+
+const categoryLabel = (
+  code: "management-book" | "classic-book" | "business-practice" | null,
+) => {
+  switch (code) {
+    case "management-book":
+      return "경영서";
+    case "classic-book":
+      return "고전명작";
+    case "business-practice":
+      return "기업실무·한국경제사";
+    default:
+      return "기타";
+  }
+};
+
+export default async function MemberTemplatesPage() {
+  const templates = await listTemplates();
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12 sm:py-20">
+      <section className="mb-10 space-y-4 text-center sm:text-left">
+        <Badge
+          variant="outline"
+          className="border-blue-300 bg-blue-50 text-blue-700"
+        >
+          HRA TEMPLATES
+        </Badge>
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight text-[#1a1a1a]">
+          보고서 양식
+        </h1>
+        <p className="max-w-2xl text-sm text-[#666666] md:text-base mx-auto sm:mx-0">
+          분야별 보고서 작성용 표준 양식입니다. 양식을 미리 보고 PDF로 다운로드하여 사용하세요.
+        </p>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Link
+            href="/member/guides/report-writing-guide"
+            className="text-[#2563EB] hover:underline"
+          >
+            작성 가이드 →
+          </Link>
+          <span className="text-[#D9D9D9]">|</span>
+          <Link
+            href="/member/guides/markdown-guide"
+            className="text-[#2563EB] hover:underline"
+          >
+            Markdown 문법 →
+          </Link>
+          <span className="text-[#D9D9D9]">|</span>
+          <Link
+            href="/member/guides/submission-guide"
+            className="text-[#2563EB] hover:underline"
+          >
+            제출 안내 →
+          </Link>
+        </div>
+      </section>
+
+      {templates.length === 0 ? (
+        <Card className="border-[#D9D9D9] bg-white shadow-[var(--shadow-soft)] rounded-2xl py-10">
+          <CardContent className="text-center text-base text-[#666666]">
+            등록된 양식이 없습니다.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          {templates.map((template) => (
+            <Link
+              key={template.slug}
+              href={`/member/templates/${template.slug}`}
+              className="block"
+            >
+              <Card className="h-full border-[#D9D9D9] bg-white text-[#1a1a1a] shadow-[var(--shadow-soft)] rounded-2xl transition hover:border-blue-400 hover:bg-gray-50">
+                <CardHeader className="space-y-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex size-11 items-center justify-center rounded-full border border-[#D9D9D9] bg-gray-50 text-[#2563EB]">
+                      <FileCheck2 className="size-5" />
+                    </div>
+                    <Badge
+                      variant="secondary"
+                      className="border border-[#D9D9D9] bg-gray-50 text-[#666666]"
+                    >
+                      v{template.version}
+                    </Badge>
+                  </div>
+                  <div className="space-y-1">
+                    <Badge
+                      variant="outline"
+                      className="border-[#D9D9D9] bg-white text-[#666666]"
+                    >
+                      {categoryLabel(template.reportCategory)}
+                    </Badge>
+                    <CardTitle className="text-xl">{template.title}</CardTitle>
+                  </div>
+                  {template.description ? (
+                    <CardDescription className="text-sm leading-6 text-[#666666]">
+                      {template.description}
+                    </CardDescription>
+                  ) : null}
+                </CardHeader>
+                <CardContent>
+                  <Button
+                    variant="outline"
+                    className="w-full border-[#D9D9D9] text-[#1a1a1a]"
+                  >
+                    양식 보기 <ArrowRight className="size-4 ml-2" />
+                  </Button>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(member)/resources/page.tsx
+++ b/src/app/(member)/resources/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight, Download, Info } from "lucide-react";
+import { ArrowRight, BookOpen, Download, FileCheck2, Info, Send } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -107,6 +107,61 @@ export default async function ResourcesPage() {
               </p>
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="mt-12 sm:mt-16">
+        <div className="mb-6 sm:mb-8 flex items-center justify-between gap-4">
+          <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight text-[#1a1a1a]">
+            보고서 양식·가이드
+          </h2>
+          <Badge variant="outline" className="border-[#D9D9D9] bg-white text-[#666666]">
+            3개
+          </Badge>
+        </div>
+
+        <div className="grid gap-6 grid-cols-1 md:grid-cols-3">
+          <Link href="/member/templates" className="block">
+            <Card className="h-full border-[#D9D9D9] bg-white text-[#1a1a1a] shadow-[var(--shadow-soft)] rounded-2xl transition hover:border-blue-400 hover:bg-gray-50">
+              <CardHeader className="space-y-4">
+                <div className="flex size-11 items-center justify-center rounded-full border border-[#D9D9D9] bg-gray-50 text-[#2563EB]">
+                  <FileCheck2 className="size-5" />
+                </div>
+                <CardTitle className="text-lg">보고서 양식</CardTitle>
+                <CardDescription className="text-sm leading-6 text-[#666666]">
+                  경영서·고전명작·기업실무 보고서 작성용 표준 양식. PDF 다운로드 지원.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+
+          <Link href="/member/guides/report-writing-guide" className="block">
+            <Card className="h-full border-[#D9D9D9] bg-white text-[#1a1a1a] shadow-[var(--shadow-soft)] rounded-2xl transition hover:border-blue-400 hover:bg-gray-50">
+              <CardHeader className="space-y-4">
+                <div className="flex size-11 items-center justify-center rounded-full border border-[#D9D9D9] bg-gray-50 text-[#2563EB]">
+                  <BookOpen className="size-5" />
+                </div>
+                <CardTitle className="text-lg">작성 가이드</CardTitle>
+                <CardDescription className="text-sm leading-6 text-[#666666]">
+                  보고서 양식의 각 항목을 어떻게 채울지 상세 안내. Markdown 문법 포함.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+
+          <Link href="/member/guides/submission-guide" className="block">
+            <Card className="h-full border-[#D9D9D9] bg-white text-[#1a1a1a] shadow-[var(--shadow-soft)] rounded-2xl transition hover:border-blue-400 hover:bg-gray-50">
+              <CardHeader className="space-y-4">
+                <div className="flex size-11 items-center justify-center rounded-full border border-[#D9D9D9] bg-gray-50 text-[#2563EB]">
+                  <Send className="size-5" />
+                </div>
+                <CardTitle className="text-lg">제출 안내</CardTitle>
+                <CardDescription className="text-sm leading-6 text-[#666666]">
+                  PDF 변환·파일명 규칙·제출 경로·마감 일정 등 실제 제출 절차.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
         </div>
       </section>
 


### PR DESCRIPTION
원본 PR #25를 main 기준으로 재타겟팅 (stacked PR 머지 과정에서 base 브랜치 자동 삭제로 #25 닫힘).

## 주요 변경
- /member/templates 목록·상세·인쇄(/print) 페이지
- /member/guides/[slug] 가이드 상세
- 'PDF로 저장' UX (window.print 기반)
- 인쇄 시 A4 레이아웃 + no-print 컨트롤

리뷰: PR #25 기록 참조