### PR TITLE
fix(security): /member/* 경로 인증 보호 추가

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -210,6 +210,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         return !!auth?.user;
       }
 
+      if (pathname.startsWith("/member")) {
+        return !!auth?.user;
+      }
+
       if (pathname.startsWith("/mypage")) {
         return !!auth?.user;
       }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,7 @@ export const config = {
   matcher: [
     "/admin/:path*",
     "/resources/:path*",
+    "/member/:path*",
     "/mypage/:path*",
   ],
 };

--- a/tests/e2e/auth-protection.spec.ts
+++ b/tests/e2e/auth-protection.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * 비로그인 접근 차단 회귀 테스트
+ *
+ * 역할: proxy.ts matcher와 auth.ts authorized 콜백이 보호 영역(/admin, /resources,
+ *       /member, /mypage)을 모두 차단하는지 확인한다. 특히 /member/* 는 보고서
+ *       양식·가이드 회원 전용 영역이므로 이 회귀 테스트가 보안 게이트 역할을 한다.
+ */
+
+import { expect, test } from "@playwright/test";
+
+const protectedPaths = [
+  "/admin",
+  "/admin/templates",
+  "/resources",
+  "/member/templates",
+  "/member/templates/management-book",
+  "/member/templates/management-book/print",
+  "/member/guides/report-writing-guide",
+  "/mypage",
+];
+
+for (const path of protectedPaths) {
+  test(`비로그인 사용자가 ${path} 접근 시 로그인 페이지로 이동한다`, async ({
+    page,
+  }) => {
+    const response = await page.goto(path);
+    // NextAuth는 미인증 시 로그인 페이지로 리다이렉트하거나 401을 반환한다.
+    // 최종 URL이 /login 으로 시작하면 통과로 간주한다.
+    expect(page.url()).toMatch(/\/login(\?|$)/);
+    // 응답 자체는 200(로그인 페이지)이어야 한다.
+    expect(response?.status()).toBeLessThan(400);
+  });
+}


### PR DESCRIPTION
## Summary

- PR #28에서 `/member/templates`, `/member/guides` 경로를 추가했지만 인증 보호 설정이 누락되어, 비로그인 사용자가 직접 URL을 입력하면 회원 전용 콘텐츠(보고서 양식·가이드)에 접근 가능했던 보안 결함을 수정합니다.
- `proxy.ts` matcher와 `auth.ts` `authorized` 콜백 양쪽에 `/member` 분기를 추가하여, 기존 `/admin`, `/resources`, `/mypage`와 동일하게 미인증 시 `/login`으로 리다이렉트되도록 합니다.

## Changes

- `src/proxy.ts`: matcher 배열에 `/member/:path*` 추가
- `src/lib/auth.ts`: `authorized` 콜백에 `/member` startsWith 분기 추가
- `tests/e2e/auth-protection.spec.ts`: 보호 경로 8개(`/admin`, `/admin/templates`, `/resources`, `/member/templates`, `/member/templates/management-book`, `/member/templates/management-book/print`, `/member/guides/report-writing-guide`, `/mypage`) 비로그인 접근 시 `/login` 리다이렉트 회귀 테스트 신규 작성

## Verification

- [x] tsc 0 errors
- [x] lint 0 errors
- [x] `npm run build` 성공
- [x] Vitest 24/24 PASS
- [ ] Vercel preview 확인 예정