### PR TITLE
feat(press): 언론보도 페이지를 카드형에서 게시판 형태로 변경

### DIFF
--- a/src/app/(public)/press/page.tsx
+++ b/src/app/(public)/press/page.tsx
@@ -1,7 +1,13 @@
+/**
+ * 공개 언론보도 페이지입니다.
+ * 카드 형태가 아니라 단순 게시판(목록) 형태로 표시합니다.
+ * - 데스크톱: 번호 / 제목 / 매체 / 날짜 4열 테이블
+ * - 모바일: 제목과 매체·날짜를 세로로 적층
+ * 행 전체가 외부 기사 링크로 동작하며 새 탭에서 열립니다.
+ */
+
 import type { Metadata } from "next";
-import Image from "next/image";
 import { asc, desc } from "drizzle-orm";
-import { ExternalLink } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { db } from "@/lib/db";
 import { pressArticles } from "@/lib/db/schema";
@@ -13,12 +19,16 @@ export const metadata: Metadata = {
   description: "HRA의 활동과 비전이 다양한 언론 매체를 통해 어떻게 소개되었는지 확인해보세요.",
 };
 
+// 게시판에 표시할 날짜 형식 (예: 2025.04.26)
 const formatDate = (value: Date) =>
   new Intl.DateTimeFormat("ko-KR", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
-  }).format(value);
+  })
+    .format(value)
+    .replace(/\.\s?$/, "")
+    .replace(/\.\s/g, ".");
 
 export default async function PressPage() {
   const articles = await db
@@ -26,8 +36,11 @@ export default async function PressPage() {
     .from(pressArticles)
     .orderBy(asc(pressArticles.order), desc(pressArticles.publishedAt));
 
+  // 게시판 번호는 최신순(상단)부터 큰 번호 부여
+  const totalCount = articles.length;
+
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12 sm:py-20 md:py-32">
+    <div className="mx-auto max-w-5xl px-4 sm:px-6 py-12 sm:py-20 md:py-32">
       <section className="mb-10 space-y-4 sm:mb-14">
         <Badge variant="outline" className="border-blue-300 bg-blue-50 text-blue-700">
           HRA PRESS
@@ -41,54 +54,57 @@ export default async function PressPage() {
       </section>
 
       {articles.length === 0 ? (
-        <div className="rounded-2xl border border-[#D9D9D9] bg-white px-6 py-16 text-center text-base text-[#666666] shadow-[var(--shadow-soft)]">
+        <div className="rounded-lg border border-[#D9D9D9] bg-white px-6 py-16 text-center text-base text-[#666666]">
           등록된 언론보도가 없습니다
         </div>
       ) : (
-        <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-          {articles.map((article) => (
-            <a
-              key={article.id}
-              href={article.url}
-              target="_blank"
-              rel="noreferrer"
-              className="group overflow-hidden rounded-2xl border border-[#D9D9D9] bg-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-1 hover:border-blue-400 hover:bg-gray-50"
-            >
-              {article.imageUrl ? (
-                <Image
-                  src={article.imageUrl}
-                  alt={`${article.title} 썸네일`}
-                  width={640}
-                  height={360}
-                  className="aspect-[16/9] w-full border-b border-[#D9D9D9] object-cover"
-                />
-              ) : (
-                <div className="flex aspect-[16/9] w-full items-center justify-center border-b border-[#D9D9D9] bg-gradient-to-br from-slate-100 via-slate-50 to-white text-sm font-medium text-[#666666]">
-                  HRA PRESS
-                </div>
-              )}
+        <section
+          aria-label="언론보도 목록"
+          className="overflow-hidden rounded-lg border border-[#D9D9D9] bg-white"
+        >
+          {/* 데스크톱용 헤더 행 (모바일에서는 숨김) */}
+          <div className="hidden border-b border-[#D9D9D9] bg-[#F5F5F5] md:grid md:grid-cols-[80px_1fr_180px_140px] md:items-center md:px-6 md:py-3">
+            <span className="text-sm font-semibold text-[#666666]">번호</span>
+            <span className="text-sm font-semibold text-[#666666]">제목</span>
+            <span className="text-sm font-semibold text-[#666666]">매체</span>
+            <span className="text-right text-sm font-semibold text-[#666666]">날짜</span>
+          </div>
 
-              <div className="flex h-full flex-col p-6">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-sm font-semibold text-blue-600">{article.source}</span>
-                  <span className="text-xs text-[#666666]">{formatDate(article.publishedAt)}</span>
-                </div>
+          <ul className="divide-y divide-[#D9D9D9]">
+            {articles.map((article, index) => {
+              // 최신 항목이 가장 큰 번호를 갖도록 (게시판 일반 규칙)
+              const number = totalCount - index;
+              return (
+                <li key={article.id}>
+                  <a
+                    href={article.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block px-4 py-4 transition-colors hover:bg-[#F5F5F5] md:grid md:grid-cols-[80px_1fr_180px_140px] md:items-center md:gap-4 md:px-6 md:py-4"
+                  >
+                    {/* 번호 (모바일 숨김) */}
+                    <span className="hidden text-sm text-[#666666] md:block">{number}</span>
 
-                <h2 className="mt-3 line-clamp-2 text-xl font-semibold leading-snug text-[#1a1a1a] transition-colors group-hover:text-blue-700">
-                  {article.title}
-                </h2>
+                    {/* 제목 */}
+                    <span className="block text-base font-medium text-[#1a1a1a] hover:text-[#2563EB] md:truncate">
+                      {article.title}
+                    </span>
 
-                <p className="mt-4 flex-1 text-sm leading-6 text-[#666666]">
-                  {article.description?.trim() || "기사 요약이 등록되지 않았습니다."}
-                </p>
-
-                <div className="mt-6 flex items-center gap-2 text-sm font-medium text-[#1a1a1a]">
-                  <ExternalLink className="size-4 text-[#666666]" />
-                  기사 보러가기
-                </div>
-              </div>
-            </a>
-          ))}
+                    {/* 매체와 날짜 — 모바일에서는 한 줄로, 데스크톱에서는 별도 컬럼으로 */}
+                    <span className="mt-1 block text-sm text-[#666666] md:mt-0 md:hidden">
+                      {article.source} · {formatDate(article.publishedAt)}
+                    </span>
+                    <span className="hidden text-sm text-[#666666] md:block md:truncate">
+                      {article.source}
+                    </span>
+                    <span className="hidden text-right text-sm text-[#666666] md:block">
+                      {formatDate(article.publishedAt)}
+                    </span>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
         </section>
       )}
     </div>


### PR DESCRIPTION
## Summary
- 언론보도 페이지를 카드 그리드 → 4열 게시판(번호/제목/매체/날짜) 형태로 변경
- 모바일 반응형: 제목 + "매체 · 날짜" 적층 레이아웃
- 불필요한 Image, ExternalLink import 제거, 날짜 형식 yyyy.MM.dd 통일

## Changes
- `src/app/(public)/press/page.tsx` — 전면 재작성 (카드 → 게시판)